### PR TITLE
Basic support for video classification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,12 @@
 PORT=8081
 API_TOKEN=myapitokenchangethislater
 ENABLE_API_TOKEN=false
-ENABLE_CONTENT_TYPE_CHECK=true
+
+# (Optional. Default: false) Ensure content type check via header request (HEAD)
+ENABLE_CONTENT_TYPE_CHECK=false
+
+# (Optional. Default: 100) Maximum size of video for classification in MB.
+MAX_VIDEO_SIZE_MB=100
+
+# (Optional. Default: automatically inferred from ffmpeg.path dependency) Set to other path for ffmpeg installed in system (example: /usr/bin/ffmpeg) otherwise use from ffmpeg pre-installed dependency 
+# FFMPEG_PATH=

--- a/README.md
+++ b/README.md
@@ -1,30 +1,39 @@
 # nsfw-detector-api
+
 A simple PoC (Proof of Concept) NSFW Detector API Server using [NsfwSpy.js](https://github.com/NsfwSpy/NsfwSpy.js) model. The goal of this PoC is to be a simple example of how to integrate existing ML model in API server.
 
-## Demo
-A demo instance is available on [HuggingFace Spaces - https://atrifat-nsfw-detector-api-demo.hf.space/](https://atrifat-nsfw-detector-api-demo.hf.space/) using default `API_TOKEN` as shown in `.env.example` file.
+nsfw-detector-api is a core dependency of [nostr-filter-relay](https://github.com/atrifat/nostr-filter-relay).
 
 ## Getting Started
+
 Published docker image is available in [ghcr.io](https://github.com/atrifat/nsfw-detector-api/pkgs/container/nsfw-detector-api).
 Run it instantly:
+
 ```
 docker run --init --rm -p 8081:8081 ghcr.io/atrifat/nsfw-detector-api:latest
 ```
 
 You can also clone this repository to run or modify it locally
+
 ```
 git clone https://github.com/atrifat/nsfw-detector-api
 cd nsfw-detector-api
 ```
+
 install its dependencies
+
 ```
 npm install
 ```
+
 and run it using command
+
 ```
 npm run start
 ```
+
 or run it using node command directly
+
 ```
 node src/index.mjs
 ```
@@ -32,6 +41,7 @@ node src/index.mjs
 If you want to test the API server, you can use GUI tools like [Postman](https://www.postman.com/) or using curl.
 
 Send request by using image URL:
+
 ```
 curl --header "Content-Type: application/json" \
   --header "Authorization: Bearer myapitokenchangethislater" \
@@ -39,7 +49,9 @@ curl --header "Content-Type: application/json" \
   --data '{"url":"https://example.org/image.jpg"}' \
   http://localhost:8081/predict
 ```
+
 or send request by using base64 string of the image:
+
 ```
 curl --header "Content-Type: application/json" \
   --header "Authorization: Bearer myapitokenchangethislater" \
@@ -47,7 +59,9 @@ curl --header "Content-Type: application/json" \
   --data '{"data":"base64stringhere"}' \
   http://localhost:8081/predict_data
 ```
+
 The output is JSON which consists of four predicted classes (based on [NsfwSpy.js](https://github.com/NsfwSpy/NsfwSpy.js)) as follows:
+
 ```
 {
     "data": {
@@ -61,8 +75,10 @@ The output is JSON which consists of four predicted classes (based on [NsfwSpy.j
 ```
 
 ## License
+
 MIT
 
 ## Author
+
 - Rif'at Ahdi Ramadhani (atrifat)
 - d00M_L0rDz (NsfwSpy)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
+        "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@tensorflow/tfjs-node-gpu": "^4.20.0",
         "await-to-js": "^3.0.0",
         "axios": "^1.7.2",
@@ -26,6 +27,123 @@
         "@types/node": "^20.6.0",
         "nodemon": "^3.0.1"
       }
+    },
+    "node_modules/@ffmpeg-installer/darwin-arm64": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-arm64/-/darwin-arm64-4.1.5.tgz",
+      "integrity": "sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/darwin-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-x64/-/darwin-x64-4.1.0.tgz",
+      "integrity": "sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/ffmpeg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/ffmpeg/-/ffmpeg-1.1.0.tgz",
+      "integrity": "sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==",
+      "optionalDependencies": {
+        "@ffmpeg-installer/darwin-arm64": "4.1.5",
+        "@ffmpeg-installer/darwin-x64": "4.1.0",
+        "@ffmpeg-installer/linux-arm": "4.1.3",
+        "@ffmpeg-installer/linux-arm64": "4.1.4",
+        "@ffmpeg-installer/linux-ia32": "4.1.0",
+        "@ffmpeg-installer/linux-x64": "4.1.0",
+        "@ffmpeg-installer/win32-ia32": "4.1.0",
+        "@ffmpeg-installer/win32-x64": "4.1.0"
+      }
+    },
+    "node_modules/@ffmpeg-installer/linux-arm": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm/-/linux-arm-4.1.3.tgz",
+      "integrity": "sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==",
+      "cpu": [
+        "arm"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/linux-arm64": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm64/-/linux-arm64-4.1.4.tgz",
+      "integrity": "sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/linux-ia32": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-ia32/-/linux-ia32-4.1.0.tgz",
+      "integrity": "sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/linux-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-x64/-/linux-x64-4.1.0.tgz",
+      "integrity": "sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/win32-ia32": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-ia32/-/win32-ia32-4.1.0.tgz",
+      "integrity": "sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ffmpeg-installer/win32-x64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-x64/-/win32-x64-4.1.0.tgz",
+      "integrity": "sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "nodemon": "^3.0.1"
   },
   "dependencies": {
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@tensorflow/tfjs-node-gpu": "^4.20.0",
     "await-to-js": "^3.0.0",
     "axios": "^1.7.2",

--- a/src/download.mjs
+++ b/src/download.mjs
@@ -2,16 +2,17 @@ import * as fs from "node:fs";
 import axios from "axios";
 import mime from "mime";
 
-export const downloadFile = async function (src, dest) {
+export const downloadFile = async function (src, dest, headers) {
   return await axios({
     method: "GET",
     url: src,
     responseType: "stream",
+    headers: headers
   })
     .then(function (response) {
       if (
         response &&
-        response.status === 200 &&
+        (response.status === 200 || response.status === 206) &&
         typeof response.data !== "undefined" &&
         response.data !== null
       ) {
@@ -35,6 +36,74 @@ export const downloadFile = async function (src, dest) {
     .catch(function (e) {
       throw new Error(e);
     });
+};
+
+const saveOutput = async (outputFile, response, size) => {
+  const writeStream = fs.createWriteStream(outputFile);
+  response.data.pipe(writeStream);
+
+  let receivedLength = 0;
+
+  return new Promise((resolve, reject) => {
+    response.data.on('data', (chunk) => {
+      receivedLength += chunk.length;
+      if (receivedLength > size) {
+        // Abort the download immediately when downloaded file exceeds content length
+        response.data.destroy();
+        reject(new Error('Downloaded size exceeds content length.'));
+      }
+    });
+
+    writeStream.on('finish', async () => {
+      resolve(true);
+    });
+
+    writeStream.on("error", (error) => {
+      reject(error);
+    });
+  });
+};
+
+export const downloadPartFile = async (url, outputFile, maxVideoSize) => {
+  maxVideoSize = maxVideoSize !== undefined ? maxVideoSize : 1024 * 1024 * 100;
+
+  let response = await axios.head(url);
+  // console.log(response.headers);
+
+  // Check and follow redirect if it is available
+  if (response.headers.get('location') != undefined) {
+    const newUrl = response.headers.get('location');
+    // console.log("redirect", newUrl);
+    url = newUrl;
+    response = await axios.head(url);
+  }
+
+  const fileSize = parseInt(response.headers['content-length']);
+  console.debug(url, "fileSize (MB)", (fileSize / (1024 * 1024)));
+
+  // Download immediately if file is smaller than target partial size (1 MiB)
+  if (fileSize < maxVideoSize) {
+    // console.log("download immediately");
+    const response = await axios.get(url, { responseType: 'stream' });
+    await saveOutput(outputFile, response, fileSize);
+    return true;
+  }
+
+  // Set range headers to download with partial bytes size
+  const headers = {
+    Range: `bytes=0-${maxVideoSize - 1}`
+  };
+
+  response = await axios.get(url, { headers, responseType: 'stream' });
+
+  if (response.status === 206) {
+    // console.log("Server returned partial content.");
+    await saveOutput(outputFile, response, maxVideoSize);
+    return true;
+  } else if (response.status === 416) {
+    console.error("Server does not support Range header request.");
+    return false;
+  }
 };
 
 export const getContentInfo = async function (src) {
@@ -66,27 +135,3 @@ export const getContentInfo = async function (src) {
       throw new Error(e);
     });
 };
-
-export const getPathType = function (path) {
-  var strs = path.split("?");
-  var index = strs[0].lastIndexOf(".");
-  if (index == -1) {
-    return "unknown";
-  }
-
-  path = strs[0];
-  var n = path.substring(index);
-  n = n.toLowerCase();
-
-  if (n == ".png" ||
-    n == ".jpg" ||
-    n == ".jpeg" ||
-    n == ".gif" ||
-    n == ".webp") {
-    return "image";
-  } else if (n == ".mp4" || n == ".mov" || n == ".wmv" || n == ".m3u8") {
-    return "video";
-  } else {
-    return "link";
-  }
-}

--- a/src/ffmpeg-util.mjs
+++ b/src/ffmpeg-util.mjs
@@ -1,0 +1,20 @@
+import * as ffmpeg from "@ffmpeg-installer/ffmpeg";
+import { runCommand } from "./util.mjs";
+
+export const generateScreenshot = async (inputFile, outputFile, ffmpegPath = '') => {
+    try {
+        const ffmpegBinary = ffmpegPath !== '' ? ffmpegPath : ffmpeg.path;
+        const result = await runCommand(ffmpegBinary, [
+            "-ignore_unknown", "-y", "-an", "-dn",
+            // "-max_error_rate", 0.5,
+            "-i", inputFile, "-ss", "00:00:01", "-vf", "thumbnail",
+            "-update", 1, "-frames:v", 1, outputFile
+        ]);
+        return true;
+    }
+    catch (err) {
+        console.error(err.message);
+        return false;
+    }
+
+};

--- a/src/util.mjs
+++ b/src/util.mjs
@@ -1,10 +1,41 @@
 import urlRegexSafe from "url-regex-safe";
 import * as fs from "node:fs";
 import { exit } from "process";
+import { spawn } from 'node:child_process';
 
 export const isContentTypeImageType = function (contentType) {
   return contentType.includes("image");
 };
+
+export const isContentTypeVideoType = function (contentType) {
+  return contentType.includes("video");
+};
+
+// Check url type
+// Code is modified based on https://github.com/haorendashu/nostrmo/blob/main/lib/component/content/content_decoder.dart#L505
+export const getUrlType = function (path) {
+  var strs = path.split("?");
+  var index = strs[0].lastIndexOf(".");
+  if (index == -1) {
+    return "unknown";
+  }
+
+  path = strs[0];
+  var n = path.substring(index);
+  n = n.toLowerCase();
+
+  if (n == ".png" ||
+    n == ".jpg" ||
+    n == ".jpeg" ||
+    n == ".gif" ||
+    n == ".webp") {
+    return "image";
+  } else if (n == ".mp4" || n == ".mov" || n == ".wmv" || n == ".webm" || n == ".avi") {
+    return "video";
+  } else {
+    return "link";
+  }
+}
 
 export const extractUrl = function (text) {
   const matches = text.match(
@@ -33,6 +64,44 @@ export async function deleteFile(filePath) {
     fs.unlink(filePath, (err) => {
       if (err) reject(err);
       resolve(true);
+    });
+  });
+}
+
+export async function moveFile(srcPath, dstPath) {
+  return new Promise((resolve, reject) => {
+    fs.rename(srcPath, dstPath, (err) => {
+      if (err) reject(err);
+      resolve(true);
+    });
+  });
+}
+
+export async function runCommand(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, options);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (code, error) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(`Command failed with code ${code}.\nStderr: ${stderr}`));
+      }
+    });
+
+    child.on('error', (error) => {
+      reject(error);
     });
   });
 }


### PR DESCRIPTION
This PR introduces new feature to support basic video classification. User/other apps can request using video URL to API server.

Data flow is similar to regular image classification:
Video URL Request -> Video will be downloaded -> Extract single frame -> Classify image frame

Currently, it was limited to classify single frame of video. Support for multiple frames might be implemented in future.
