### PR TITLE
feat: Introduce WORKER_POOL_MAX_WORKERS for worker pool scaling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,6 @@ USER_AGENT='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
 
 # (Optional. Default: 2) Minimum number of workers in the worker pool for NSFW detection and image processing.
 WORKER_POOL_MIN_WORKERS=2
+
+# (Optional. Default: WORKER_POOL_MIN_WORKERS or 2) Maximum number of workers in the worker pool. Falls back to MIN_WORKERS if not set, then to 2.
+WORKER_POOL_MAX_WORKERS=4

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following environment variables can be used to configure the API server:
 *   `REQUEST_TIMEOUT_IN_SECONDS`: Request timeout for downloading image or checking image header in seconds (default: 60).
 *   `USER_AGENT`: User agent for downloading files (default: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36').
 *   `WORKER_POOL_MIN_WORKERS`: Minimum number of workers in the worker pool for NSFW detection and image processing (default: 2).
+*   `WORKER_POOL_MAX_WORKERS`: Maximum number of workers in the worker pool. Falls back to `WORKER_POOL_MIN_WORKERS` if not set, then to 2.
 
 ## License
 

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -4,6 +4,9 @@ import * as dotenv from 'dotenv'
 // Load environment variables from .env file
 dotenv.config()
 
+// Parse MIN_WORKERS first as it's a fallback for MAX_WORKERS
+const minWorkers = parseInt(process.env.WORKER_POOL_MIN_WORKERS || 2)
+
 /**
  * Application configuration object.
  */
@@ -29,5 +32,9 @@ export const config = {
   USER_AGENT:
     process.env.USER_AGENT ||
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
-  WORKER_POOL_MIN_WORKERS: parseInt(process.env.WORKER_POOL_MIN_WORKERS || 2),
+  WORKER_POOL_MIN_WORKERS: minWorkers, // Use the parsed value
+  // Implement the fallback logic for MAX_WORKERS
+  WORKER_POOL_MAX_WORKERS: parseInt(
+    process.env.WORKER_POOL_MAX_WORKERS || minWorkers
+  ),
 }

--- a/src/nsfw-detector-factory.mjs
+++ b/src/nsfw-detector-factory.mjs
@@ -50,6 +50,7 @@ export const createNsfwSpy = async (modelPath) => {
 export const createNsfwDetectorWorkerPool = async (config) => {
   const nsfwDetectorPool = workerpool.pool(nsfwDetectorWorkerScriptPath, {
     minWorkers: config.WORKER_POOL_MIN_WORKERS,
+    maxWorkers: config.WORKER_POOL_MAX_WORKERS,
   })
 
   return nsfwDetectorPool
@@ -63,6 +64,7 @@ export const createNsfwDetectorWorkerPool = async (config) => {
 export const createImageProcessingWorkerPool = async (config) => {
   const imageProcessingPool = workerpool.pool(imageProcessingWorkerScriptPath, {
     minWorkers: config.WORKER_POOL_MIN_WORKERS,
+    maxWorkers: config.WORKER_POOL_MAX_WORKERS,
   })
 
   return imageProcessingPool


### PR DESCRIPTION
This PR introduces a new environment variable `WORKER_POOL_MAX_WORKERS` to allow scaling the worker pool. It falls back to `WORKER_POOL_MIN_WORKERS` if not set, and then to a default of 2. This change improves the application's ability to handle varying workloads.