### PR TITLE
fix: Harden against resource leaks and fix open test handles

### DIFF
--- a/__tests__/ffmpeg-util.test.mjs
+++ b/__tests__/ffmpeg-util.test.mjs
@@ -351,7 +351,8 @@ describe('generateScreenshot', () => {
     await generateScreenshot('/path/to/video.mp4', '/path/to/screenshot.jpg')
     expect(runCommandMock).toHaveBeenCalledWith(
       '/usr/bin/ffmpeg',
-      expect.any(Array)
+      expect.any(Array),
+      { timeout: 15000 }
     )
   })
 

--- a/__tests__/prediction-handler.test.mjs
+++ b/__tests__/prediction-handler.test.mjs
@@ -1,6 +1,11 @@
 import { jest } from '@jest/globals'
 import { Readable } from 'node:stream' // Import Readable
 
+import {
+  nsfwDetectorWorkerPool,
+  imageProcessingWorkerPool,
+} from '../src/resources.mjs'
+
 // Set up mocks before importing modules to ensure they are applied before the module under test
 // is imported. This is crucial for unstable_mockModule.
 
@@ -148,6 +153,12 @@ const mockConfig = {
   CACHE_DURATION_IN_SECONDS: 3600,
   VIDEO_PROCESSING_CONCURRENCY: 5, // Add mock value for tests
 }
+
+// // Gracefully terminate the worker pools after all tests have run
+afterAll(async () => {
+  await nsfwDetectorWorkerPool.terminate()
+  await imageProcessingWorkerPool.terminate()
+})
 
 describe('Prediction Handlers', () => {
   let mockReq

--- a/src/download.mjs
+++ b/src/download.mjs
@@ -68,6 +68,11 @@ export const downloadFile = async function (
 
       // Return a promise and resolve when download finishes
       return new Promise((resolve, reject) => {
+        response.data.on('error', (error) => {
+          writer.close()
+          reject(error)
+        })
+
         writer.on('finish', () => {
           resolve(true)
         })

--- a/src/ffmpeg-util.mjs
+++ b/src/ffmpeg-util.mjs
@@ -34,7 +34,7 @@ export const generateScreenshot = async (
       outputFile, // Output file
     ]
 
-    await runCommand(ffmpegBinary, args)
+    await runCommand(ffmpegBinary, args, { timeout: 15000 }) // Set a 15-second timeout
     return true
   } catch (err) {
     console.error(`Error generating screenshot: ${err.message}`)


### PR DESCRIPTION
This PR addresses several potential sources of resource leaks and dangling resources:

1.  **Orphaned FFmpeg Processes:** The fallback screenshot function (`generateScreenshot`) did not have a timeout. A malformed or slow-to-process video could cause the spawned FFmpeg process to hang indefinitely. A 15-second timeout has been added to the command execution to prevent this.

2.  **Incomplete Download Error Handling:** The `downloadFile` function was not handling errors on the source `axios` stream. If a download failed mid-stream, the promise would never reject, potentially leaving a partial file on disk. An error handler has been added to the source stream to ensure errors are propagated and resources are cleaned up.

3.  **Open Handles in Tests:** The worker pools were not being terminated in `prediction-handler.test.mjs`, causing Jest to report open handles. An `afterAll` hook has been added to gracefully terminate the pools.