### PR TITLE
feat(server): Add request cancellation on client disconnect

### DIFF
--- a/__tests__/prediction-handler.test.mjs
+++ b/__tests__/prediction-handler.test.mjs
@@ -232,7 +232,12 @@ describe('Prediction Handlers', () => {
         expectedClassification
       )
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockResultCache.get).toHaveBeenCalledWith(
         expect.stringContaining('url-')
@@ -272,7 +277,12 @@ describe('Prediction Handlers', () => {
         expectedClassification
       )
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockResultCache.get).toHaveBeenCalledWith(
         expect.stringContaining('url-')
@@ -308,7 +318,12 @@ describe('Prediction Handlers', () => {
         workerError
       )
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockImageProcessingInstance.processImageFile).toHaveBeenCalled()
       expect(mockNsfwSpy.classifyImageFile).not.toHaveBeenCalled()
@@ -333,7 +348,12 @@ describe('Prediction Handlers', () => {
         workerError
       )
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockImageProcessingInstance.processImageData).toHaveBeenCalled()
       expect(mockNsfwSpy.classifyImageFromByteArray).not.toHaveBeenCalled()
@@ -352,7 +372,12 @@ describe('Prediction Handlers', () => {
 
       mockResultCache.get.mockReturnValue(cachedResult)
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockResultCache.get).toHaveBeenCalledWith(
         expect.stringContaining('url-')
@@ -397,16 +422,23 @@ describe('Prediction Handlers', () => {
         expectedClassificationVideo
       )
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockGetVideoStream).toHaveBeenCalledWith(
         mockVideoUrl,
         expect.any(Object),
-        expect.any(Number)
+        expect.any(Number),
+        expect.any(Object)
       )
       expect(mockGenerateScreenshotFromStream).toHaveBeenCalledWith(
         mockVideoStream,
-        dependencies.config.FFMPEG_PATH
+        dependencies.config.FFMPEG_PATH,
+        expect.any(Object) // Match the options object
       )
       expect(mockImageProcessingInstance.processImageData).toHaveBeenCalledWith(
         expect.any(Buffer)
@@ -453,18 +485,25 @@ describe('Prediction Handlers', () => {
         expectedClassificationVideo
       )
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockGetVideoStream).toHaveBeenCalledTimes(1) // Attempted once
       expect(mockDownloadPartFileToBuffer).toHaveBeenCalledWith(
         mockVideoUrl,
         expect.any(Number),
         expect.any(Number),
+        expect.any(Object),
         expect.any(Object)
       )
       expect(mockGenerateScreenshotFromBuffer).toHaveBeenCalledWith(
         expect.any(Buffer),
-        dependencies.config.FFMPEG_PATH
+        dependencies.config.FFMPEG_PATH,
+        expect.any(Object) // Match the options object
       )
       expect(mockImageProcessingInstance.processImageData).toHaveBeenCalledWith(
         expect.any(Buffer)
@@ -511,7 +550,12 @@ describe('Prediction Handlers', () => {
         expectedClassificationVideo
       )
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockGetVideoStream).toHaveBeenCalledTimes(1)
       expect(mockDownloadPartFileToBuffer).toHaveBeenCalledTimes(1)
@@ -520,6 +564,7 @@ describe('Prediction Handlers', () => {
         expect.stringContaining(dependencies.config.IMG_DOWNLOAD_PATH),
         expect.any(Number),
         expect.any(Number),
+        expect.any(Object),
         expect.any(Object)
       )
       expect(mockGenerateScreenshot).toHaveBeenCalledWith(
@@ -563,7 +608,12 @@ describe('Prediction Handlers', () => {
       ) // Simulate final download failure
       mockGenerateScreenshot.mockResolvedValueOnce(false) // Simulate screenshot generation failure for file path
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockGetVideoStream).toHaveBeenCalledTimes(1)
       expect(mockDownloadPartFileToBuffer).toHaveBeenCalledTimes(1)
@@ -621,7 +671,12 @@ describe('Prediction Handlers', () => {
       // and ensure the underlying functions are called as expected.
       // A more advanced test would involve mocking `p-limit` to verify its `add` method is called.
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       // Assert that the primary tier functions were called (they are wrapped by p-limit)
       expect(mockGetVideoStream).toHaveBeenCalled()
@@ -632,7 +687,12 @@ describe('Prediction Handlers', () => {
     it('should return 400 if URL is not detected', async () => {
       mockUtil.extractUrl.mockReturnValue(null)
       mockReq.body.url = 'not a url'
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
       expect(mockRes.status).toHaveBeenCalledWith(400)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: 'URL is not detected',
@@ -645,7 +705,12 @@ describe('Prediction Handlers', () => {
         'http://another.com',
       ])
       mockReq.body.url = 'http://example.com http://another.com'
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
       expect(mockRes.status).toHaveBeenCalledWith(400)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Multiple URLs are not supported',
@@ -678,7 +743,12 @@ describe('Prediction Handlers', () => {
           new Error('Final download failed')
         )
 
-        await predictUrlHandler(mockReq, mockRes, dependencies)
+        await predictUrlHandler(
+          mockReq,
+          mockRes,
+          dependencies,
+          new AbortController().signal
+        )
 
         expect(mockRes.status).toHaveBeenCalledWith(500)
         expect(mockRes.json).toHaveBeenCalledWith({
@@ -694,7 +764,12 @@ describe('Prediction Handlers', () => {
         mockDownloadPartFile.mockResolvedValueOnce(true)
         mockGenerateScreenshot.mockResolvedValueOnce(false) // Simulate failure by returning false
 
-        await predictUrlHandler(mockReq, mockRes, dependencies)
+        await predictUrlHandler(
+          mockReq,
+          mockRes,
+          dependencies,
+          new AbortController().signal
+        )
 
         expect(mockRes.status).toHaveBeenCalledWith(500)
         expect(mockRes.json).toHaveBeenCalledWith({
@@ -712,7 +787,12 @@ describe('Prediction Handlers', () => {
           new Error('Cannot read file')
         )
 
-        await predictUrlHandler(mockReq, mockRes, dependencies)
+        await predictUrlHandler(
+          mockReq,
+          mockRes,
+          dependencies,
+          new AbortController().signal
+        )
 
         expect(mockRes.status).toHaveBeenCalledWith(500)
         expect(mockRes.json).toHaveBeenCalledWith({
@@ -742,7 +822,12 @@ describe('Prediction Handlers', () => {
           expectedClassification
         )
 
-        await predictUrlHandler(mockReq, mockRes, dependencies)
+        await predictUrlHandler(
+          mockReq,
+          mockRes,
+          dependencies,
+          new AbortController().signal
+        )
 
         // Verify file-based functions were called
         expect(mockDownloadPartFile).toHaveBeenCalled()
@@ -897,7 +982,12 @@ describe('Prediction Handlers', () => {
       const downloadError = new Error('Network error')
       mockDownloadPartFile.mockRejectedValueOnce(downloadError)
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -913,7 +1003,12 @@ describe('Prediction Handlers', () => {
       mockDownloadPartFile.mockResolvedValueOnce({ status: 'downloaded' })
       mockGenerateScreenshot.mockRejectedValueOnce(screenshotError)
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -929,7 +1024,12 @@ describe('Prediction Handlers', () => {
       const downloadError = new Error('Image download failed')
       mockDownloadFile.mockRejectedValueOnce(downloadError)
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -947,7 +1047,12 @@ describe('Prediction Handlers', () => {
         processError
       )
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -964,7 +1069,12 @@ describe('Prediction Handlers', () => {
       mockImageProcessingInstance.processImageFile.mockResolvedValueOnce({})
       mockNsfwSpy.classifyImageFile.mockRejectedValueOnce(classifyError)
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -988,7 +1098,12 @@ describe('Prediction Handlers', () => {
       mockUtil.isContentTypeImageType.mockReturnValueOnce(false)
       mockUtil.isContentTypeVideoType.mockReturnValueOnce(false)
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -1002,7 +1117,12 @@ describe('Prediction Handlers', () => {
       const contentInfoError = new Error('Failed to fetch headers')
       mockGetContentInfo.mockRejectedValueOnce(contentInfoError)
 
-      await predictUrlHandler(mockReq, mockRes, dependencies)
+      await predictUrlHandler(
+        mockReq,
+        mockRes,
+        dependencies,
+        new AbortController().signal
+      )
 
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({

--- a/src/download.mjs
+++ b/src/download.mjs
@@ -49,7 +49,8 @@ export const downloadFile = async function (
   src,
   dest,
   timeout = 60000,
-  extraHeaders = {}
+  extraHeaders = {},
+  signal
 ) {
   try {
     const response = await axios({
@@ -58,6 +59,7 @@ export const downloadFile = async function (
       responseType: 'stream',
       headers: extraHeaders,
       timeout: timeout,
+      signal,
     })
 
     if (response?.data && response.status === 200) {
@@ -100,7 +102,8 @@ export const downloadFile = async function (
 export const downloadFileToBuffer = async function (
   src,
   timeout = 60000,
-  extraHeaders = {}
+  extraHeaders = {},
+  signal
 ) {
   try {
     const response = await axios({
@@ -109,6 +112,7 @@ export const downloadFileToBuffer = async function (
       responseType: 'arraybuffer',
       headers: extraHeaders,
       timeout: timeout,
+      signal,
     })
 
     if (response?.data && response.status === 200) {
@@ -177,7 +181,8 @@ export const downloadPartFile = async (
   outputFile,
   maxVideoSize,
   timeout = 60000,
-  extraHeaders = {}
+  extraHeaders = {},
+  signal
 ) => {
   const { finalUrl: redirectedUrl, response } = await handleRedirects(
     url,
@@ -198,6 +203,7 @@ export const downloadPartFile = async (
       headers: extraHeaders,
       responseType: 'stream',
       timeout: timeout,
+      signal,
     })
     await saveOutput(outputFile, getResponse, downloadSize)
     return true
@@ -213,6 +219,7 @@ export const downloadPartFile = async (
     headers: rangeHeaders,
     responseType: 'stream',
     timeout: timeout,
+    signal,
   })
 
   if (partialResponse.status === 206 || partialResponse.status === 200) {
@@ -242,7 +249,8 @@ export const downloadPartFileToBuffer = async (
   url,
   maxVideoSize,
   timeout = 60000,
-  extraHeaders = {}
+  extraHeaders = {},
+  signal
 ) => {
   const { finalUrl: redirectedUrl, response } = await handleRedirects(
     url,
@@ -263,6 +271,7 @@ export const downloadPartFileToBuffer = async (
       headers: extraHeaders,
       responseType: 'arraybuffer',
       timeout: timeout,
+      signal,
     })
     if (getResponse?.data && getResponse.status === 200) {
       return Buffer.from(getResponse.data)
@@ -281,6 +290,7 @@ export const downloadPartFileToBuffer = async (
     headers: rangeHeaders,
     responseType: 'arraybuffer',
     timeout: timeout,
+    signal,
   })
 
   if (partialResponse.status === 206 || partialResponse.status === 200) {
@@ -342,7 +352,12 @@ export const getContentInfo = async function (
  * @param {string} url - The validated video URL to fetch.
  * @returns {Promise<ReadableStream>} - A promise resolving to the readable stream.
  */
-export async function getVideoStream(url, extraHeaders = {}, timeout = 60000) {
+export async function getVideoStream(
+  url,
+  extraHeaders = {},
+  timeout = 60000,
+  signal
+) {
   let response
   try {
     response = await axios.get(url, {
@@ -350,6 +365,7 @@ export async function getVideoStream(url, extraHeaders = {}, timeout = 60000) {
       timeout: timeout,
       headers: { 'User-Agent': extraHeaders['User-Agent'] },
       maxRedirects: 5, // Follow redirects
+      signal,
     })
 
     // Axios generally throws for >= 400, but explicit check is safe

--- a/src/ffmpeg-util.mjs
+++ b/src/ffmpeg-util.mjs
@@ -65,7 +65,7 @@ export function generateScreenshotFromBuffer(
   ffmpegPath,
   options = {}
 ) {
-  const { seekTime = '00:00:01.000', timeout = 15000 } = options
+  const { seekTime = '00:00:01.000', timeout = 15000, signal } = options
   // Use robust seek args, consistent with the streaming function
   const ffmpegArgs = [
     '-hide_banner',
@@ -90,6 +90,7 @@ export function generateScreenshotFromBuffer(
   return new Promise((resolve, reject) => {
     const ffmpegProcess = spawn(ffmpegPath, ffmpegArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],
+      signal,
     })
 
     const bufferStream = Readable.from(videoBuffer) // The stream comes from the complete buffer
@@ -172,7 +173,7 @@ export function generateScreenshotFromStream(
   ffmpegPath,
   options = {}
 ) {
-  const { seekTime = '00:00:01.000', timeout = 15000 } = options
+  const { seekTime = '00:00:01.000', timeout = 15000, signal } = options
 
   // Arguments are optimized for robustly seeking on a stream.
   const ffmpegArgs = [
@@ -201,6 +202,7 @@ export function generateScreenshotFromStream(
   return new Promise((resolve, reject) => {
     const ffmpegProcess = spawn(ffmpegPath, ffmpegArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],
+      signal,
     })
 
     let outputBuffer = Buffer.alloc(0)

--- a/src/prediction-handler.mjs
+++ b/src/prediction-handler.mjs
@@ -20,7 +20,7 @@ export const processData = processDataForPrediction
  * @param {object} res - Express response object.
  * @param {object} dependencies - Injected dependencies.
  */
-export const predictUrlHandler = async (req, res, dependencies) => {
+export const predictUrlHandler = async (req, res, dependencies, signal) => {
   const url = req.body.url ?? ''
 
   // Validate URL
@@ -33,7 +33,9 @@ export const predictUrlHandler = async (req, res, dependencies) => {
   }
 
   // Process the URL and get the prediction result
-  const [err, result] = await to(processUrl(extractedUrl[0], dependencies))
+  const [err, result] = await to(
+    processUrl(extractedUrl[0], dependencies, signal)
+  )
 
   if (err) {
     // Error handling is now centralized in processUrlForPrediction, just return the error response

--- a/src/url-processor.mjs
+++ b/src/url-processor.mjs
@@ -66,7 +66,8 @@ export const processUrlForPrediction = async (
     limit,
     config,
     Mutex,
-  }
+  },
+  signal
 ) => {
   const {
     IMG_DOWNLOAD_PATH,
@@ -152,7 +153,8 @@ export const processUrlForPrediction = async (
           const result = await getScreenshotBufferWithFallbacks(
             url,
             filename,
-            params
+            params,
+            signal
           )
           if (result?.tempFilesCreated?.length) {
             tempFilesCreated.push(...result.tempFilesCreated)
@@ -171,7 +173,8 @@ export const processUrlForPrediction = async (
           downloadFileToBuffer(
             url,
             REQUEST_TIMEOUT_IN_SECONDS * 1000,
-            extraHeaders
+            extraHeaders,
+            signal
           )
         ) // Download image directly to buffer
         if (errDownload) {
@@ -192,7 +195,8 @@ export const processUrlForPrediction = async (
             videoFile,
             MAX_VIDEO_SIZE_MB * 1024 * 1024,
             REQUEST_TIMEOUT_IN_SECONDS * 1000,
-            extraHeaders
+            extraHeaders,
+            signal
           )
         )
         if (errDownload) {
@@ -224,7 +228,8 @@ export const processUrlForPrediction = async (
             url,
             downloadedFile,
             REQUEST_TIMEOUT_IN_SECONDS * 1000,
-            extraHeaders
+            extraHeaders,
+            signal
           )
         )
         if (errDownload) {


### PR DESCRIPTION
This PR introduces a request cancellation mechanism to gracefully handle cases where a client disconnects before processing is complete. Previously, the server would continue to process the request, consuming network and CPU resources for a result that would never be delivered. This could lead to resource exhaustion, especially with long-running `ffmpeg` or download tasks.

#### Changes

-   **AbortController Implementation:** An `AbortController` is now created for each incoming `/predict` request in `src/index.mjs`. A `close` event listener on the request object aborts the controller if the client connection is terminated.
-   **Signal Propagation:** The `AbortSignal` is propagated from the entry point down through the entire processing pipeline, including `prediction-handler`, `url-processor`, and `video-processor`.
-   **Graceful Termination:**
    -   All `axios` network requests in `src/download.mjs` now accept the signal to cancel in-flight downloads.
    -   The `spawn` calls for `ffmpeg` in `src/ffmpeg-util.mjs` are passed the signal to terminate the child process immediately on abort.
-   **Test Updates:** The Jest tests in `__tests__/prediction-handler.test.mjs` have been updated to mock and assert the new `AbortSignal` parameter, ensuring the cancellation logic is correctly wired.